### PR TITLE
Remove Break Lines and &nbsp from description

### DIFF
--- a/js/forum/dist/extension.js
+++ b/js/forum/dist/extension.js
@@ -23,7 +23,7 @@ System.register('avatar4eg/share-social/addMetaTags', ['flarum/app', 'flarum/com
             }
             var description = '';
             if (this.discussion.startPost()) {
-                description = truncate(getPlainContent(this.discussion.startPost().contentHtml()), 150, 0);
+                description = truncate(getPlainContent(this.discussion.startPost().contentHtml()), 150, 0).replace(/\r?\n|\r/, "");
             }
 
             $('meta[name=description]').attr('content', description);

--- a/js/forum/src/addMetaTags.js
+++ b/js/forum/src/addMetaTags.js
@@ -23,7 +23,7 @@ export default function() {
         }
         var description = '';
         if (this.discussion.startPost()) {
-            description = truncate(getPlainContent(this.discussion.startPost().contentHtml()), 150, 0);
+            description = truncate(getPlainContent(this.discussion.startPost().contentHtml()), 150, 0).replace(/\r?\n|\r/, "");;
         }
 
         $('meta[name=description]').attr('content', description);


### PR DESCRIPTION
It's important remove the Break Lines for a clear description for search engines and social media.
